### PR TITLE
`prep_scores()` gains argument `remaining_carbon_budget`

### DIFF
--- a/R/aggregate_score_function.R
+++ b/R/aggregate_score_function.R
@@ -9,12 +9,15 @@
 #' @param overview Data frame that contains overview
 #' @param scenario_source Character. Must be a
 #'   `scenario_source` featured in the `scenario_thresholds` data set.
+#' @param remaining_carbon_budgets Data-frame that contains the remaining carbon
+#' budget per sector and scenario source.
 #'
 #' @return data.frame
 #' @export
 prep_scores <- function(results_portfolio,
                         overview = overview,
-                        scenario_source = "GECO2021") {
+                        scenario_source = "GECO2021",
+                        remaining_carbon_budgets) {
 
   # infer start_year
   start_year <- min(results_portfolio$year, na.rm = TRUE)
@@ -59,9 +62,6 @@ prep_scores <- function(results_portfolio,
   # combine scores of roadmap and emission intensity sectors
   sector_aggregate_scores <- sector_aggregate_scores_tech %>%
     dplyr::bind_rows(sector_aggregate_scores_emissions)
-
-  # # get remaining carbon budgets and calculate portfolio aggregate score
-  remaining_carbon_budgets <- base::get("remaining_carbon_budgets")
 
   portfolio_aggregate_scores <- sector_aggregate_scores %>%
     calculate_portfolio_aggregate_scores(
@@ -439,7 +439,8 @@ calculate_aggregate_portfolio_score <- function(data,
 #' @export
 prep_scores_NZE <- function(results_portfolio,
                         overview = overview,
-                        scenario = "NZE_2050") {
+                        scenario = "NZE_2050",
+                        remaining_carbon_budgets_nze) {
 
   # infer start_year
   start_year <- min(results_portfolio$year, na.rm = TRUE)
@@ -478,12 +479,9 @@ prep_scores_NZE <- function(results_portfolio,
   sector_aggregate_scores <- sector_aggregate_scores_tech %>%
     dplyr::bind_rows(sector_aggregate_scores_emissions)
 
-  # # get remaining carbon budgets and calculate portfolio aggregate score
-  remaining_carbon_budgets <- base::get("remaining_carbon_budgets_nze")
-
   portfolio_aggregate_scores <- sector_aggregate_scores %>%
     calculate_portfolio_aggregate_scores(
-      remaining_carbon_budgets = remaining_carbon_budgets
+      remaining_carbon_budgets = remaining_carbon_budgets_nze
     )
 
   aggregate_portfolio_score <- portfolio_aggregate_scores %>%

--- a/R/aggregate_score_function.R
+++ b/R/aggregate_score_function.R
@@ -17,13 +17,11 @@
 prep_scores <- function(results_portfolio,
                         overview = overview,
                         scenario_source = "GECO2021",
-                        remaining_carbon_budgets) {
+                        remaining_carbon_budgets,
+                        scenario_thresholds) {
 
   # infer start_year
   start_year <- min(results_portfolio$year, na.rm = TRUE)
-
-  # get scenarios
-  scenario_thresholds <- base::get("scenario_thresholds")
 
   scenarios <- scenario_thresholds %>%
     dplyr::filter(.data$scenario_source == .env$scenario_source) %>%

--- a/R/aggregate_score_function.R
+++ b/R/aggregate_score_function.R
@@ -438,7 +438,8 @@ calculate_aggregate_portfolio_score <- function(data,
 prep_scores_NZE <- function(results_portfolio,
                         overview = overview,
                         scenario = "NZE_2050",
-                        remaining_carbon_budgets_nze) {
+                        remaining_carbon_budgets_nze,
+                        scenario_thresholds) {
 
   # infer start_year
   start_year <- min(results_portfolio$year, na.rm = TRUE)

--- a/man/prep_scores.Rd
+++ b/man/prep_scores.Rd
@@ -7,7 +7,8 @@
 prep_scores(
   results_portfolio,
   overview = overview,
-  scenario_source = "GECO2021"
+  scenario_source = "GECO2021",
+  remaining_carbon_budgets
 )
 }
 \arguments{
@@ -18,6 +19,9 @@ level PACTA results from a PACTA for investors analysis.}
 
 \item{scenario_source}{Character. Must be a
 \code{scenario_source} featured in the \code{scenario_thresholds} data set.}
+
+\item{remaining_carbon_budgets}{Data-frame that contains the remaining carbon
+budget per sector and scenario source.}
 }
 \value{
 data.frame


### PR DESCRIPTION
Since the `remaining_carbon_budget` datasets should likely remain private, I have elected to keep them in the (private) workflow repository here: https://github.com/RMI-PACTA/workflow.mfm2023

Thus, accessing them will require us to parameterize the functions that use that data to accept the data as an input. 