### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # pacta.r.package <img src="man/figures/logo.png" align="right" width="120" />
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
   <!-- badges: start -->
   [![Codecov test coverage](https://codecov.io/gh/RMI-PACTA/pacta.r.package/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RMI-PACTA/pacta.r.package?branch=main)
   [![R-CMD-check](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml)
   <!-- badges: end -->
 
 The goal of `pacta.r.package` is to provide a default template R package 
-template. This template can be used to easily scaffold new PACTA R packages. 
+template. This template can be used to easily scaffold new PACTA R packages.


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.